### PR TITLE
Update Install.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -16,7 +16,7 @@ http://tulip.labri.fr/Documentation/current/tulip-dev/html/tulip_tutorial.html
 # Install Procedure
 * Use Cmake to configure
 ```
-cmake -DCMAKE_MODULE_PATH="<path to Tulip install/share/tulip directory>;<path to Infiniband directory>" -DCMAKE_BUILD_TYPE=Release <path to Infiniband directory>
+cmake -DCMAKE_MODULE_PATH="<path to Tulip source code/cmake>;<path to Infiniband directory>" -DCMAKE_BUILD_TYPE=Release <path to Infiniband directory>
 ```
 * Compile and install
 ```
@@ -24,8 +24,12 @@ make
 make install
 ```
 
-# Example: Compelete install on a Linux host including Tulip
-* Compile and install Tulip (This assumes that all the Tulip prereqs are already installed).
+# Example: Compelete install on Ubuntu 18.04 host including Tulip
+* Install prerequisites for Tulip
+```
+sudo apt-get install build-essential git python subversion cmake cmake-curses-gui libqt4-dev libfreetype6-dev zlib1g-dev libglew-dev libjpeg-dev libpng-dev doxygen libxml2-dev qt4-dev-tools python-dev python-sphinx libqhull-dev libyajl-dev libquazip-dev libqtwebkit-dev graphviz binutils-dev libcanberra-gtk-dev
+```
+* Compile and install Tulip.
 ```
 svn checkout svn://svn.code.sf.net/p/auber/code/tulip tulip-src
 cd tulip-src
@@ -39,7 +43,6 @@ sudo make install
 ```
 git clone https://github.com/google/re2.git re2
 cd re2
-cmake .
 make
 sudo make install
 ```
@@ -57,7 +60,7 @@ sudo make install
 git clone https://github.com/nateucar/tulip_infiniband.git tulip_infiniband
 mkdir tulip_infiniband/build
 cd tulip_infiniband/build
-cmake -DCMAKE_MODULE_PATH=/usr/local/share/tulip/ ..
+cmake -DCMAKE_MODULE_PATH="<path to tulip-src>/cmake;.." -DCMAKE_BUILD_TYPE=Release ..
 make
 sudo make install
 ```


### PR DESCRIPTION
Added list of prerequisites for Tulip; some are not listed in Tulip documentation.

Removed cmake from RE2 installation in the example; RE2 comes with make files ready. 

Changed language in the tulip_infiniband cmake DCMAKE_MODULE_PATH to clarify that the path should be to the tulip source code, not where tulip is installed on the local system.