### PR TITLE
Resolve tulip plugin error. Add macOS compatibility for docker

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -29,9 +29,9 @@ make install
 ```
 sudo apt-get install build-essential git python subversion cmake cmake-curses-gui libqt4-dev libfreetype6-dev zlib1g-dev libglew-dev libjpeg-dev libpng-dev doxygen libxml2-dev qt4-dev-tools python-dev python-sphinx libqhull-dev libyajl-dev libquazip-dev libqtwebkit-dev graphviz binutils-dev libcanberra-gtk-dev
 ```
-* Compile and install Tulip.
+* Download, compile and install the latest version of Tulip.
 ```
-svn checkout svn://svn.code.sf.net/p/auber/code/tulip tulip-src
+git clone --depth=1 --single-branch -b tulip_5_1_0 https://github.com/Tulip-Dev/tulip tulip-src
 cd tulip-src
 mkdir build
 cd build
@@ -39,14 +39,14 @@ cmake ..
 make
 sudo make install
 ```
-*  Compile and install Googles RE2
+* Download, compile and install Googles RE2
 ```
 git clone https://github.com/google/re2.git re2
 cd re2
 make
 sudo make install
 ```
-* Compile and install libibautils
+* Download, compile and install libibautils
 ```
 git clone https://github.com/nateucar/libibautils.git libibautils
 mkdir libibautils/build
@@ -55,7 +55,7 @@ cmake ..
 make
 sudo make install
 ```
-* Compile and install Infinband Plugins into Tulip
+* Download, compile and install Infinband Plugins into Tulip
 ```
 git clone https://github.com/nateucar/tulip_infiniband.git tulip_infiniband
 mkdir tulip_infiniband/build

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -7,10 +7,9 @@
   * https://github.com/google/re2
 * cmake
 * c++ compiler
-* all prerequistes for Tulip
+* all prerequisites for Tulip
 
 # Reference
-
 http://tulip.labri.fr/Documentation/current/tulip-dev/html/tulip_tutorial.html
 
 # Install Procedure
@@ -24,7 +23,7 @@ make
 make install
 ```
 
-# Example: Compelete install on Ubuntu 18.04 host including Tulip
+# Example: Compelete install on Ubuntu 18.04 host
 * Install prerequisites for Tulip
 ```
 sudo apt-get install build-essential git python subversion cmake cmake-curses-gui libqt4-dev libfreetype6-dev zlib1g-dev libglew-dev libjpeg-dev libpng-dev doxygen libxml2-dev qt4-dev-tools python-dev python-sphinx libqhull-dev libyajl-dev libquazip-dev libqtwebkit-dev graphviz binutils-dev libcanberra-gtk-dev

--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -18,49 +18,47 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y \
 	libyajl-dev libquazip-dev libqtwebkit-dev graphviz \
 	binutils-dev libcanberra-gtk-dev
 
-RUN mkdir tulip
-
-WORKDIR /tulip
+RUN mkdir /src
 
 #download most recent branch of tulip source code
-RUN git clone --depth=1 --single-branch -b tulip_5_1_0 https://github.com/Tulip-Dev/tulip tulip-src
+RUN git clone --depth=1 --single-branch -b tulip_5_1_0 https://github.com/Tulip-Dev/tulip /src/tulip
 
-RUN mkdir /tulip/tulip-src/build
+RUN mkdir /src/tulip/build
 
-WORKDIR /tulip/tulip-src/build
+WORKDIR /src/tulip/build
 
 #write makefile, compile in parallel and install tulip
 RUN cmake .. && make -j 4 && make install
 
 #download re2 source code
 
-RUN git clone --depth=1 https://github.com/google/re2.git /re2
+RUN git clone --depth=1 https://github.com/google/re2.git /src/re2
 
-WORKDIR	/re2
+WORKDIR	/src/re2
 
 #compile in parallel and install re2
 RUN make -j 4 && make install
 
 #download libibautils source code
-RUN git clone --depth=1 https://github.com/nateucar/libibautils.git /libibautils
+RUN git clone --depth=1 https://github.com/nateucar/libibautils.git /src/libibautils
 
-RUN mkdir /libibautils/build
+RUN mkdir /src/libibautils/build
 
-WORKDIR /libibautils/build
+WORKDIR /src/libibautils/build
 
 #write makefile, compile in parallel and install libibautils
 RUN cmake .. && make -j 4 && make install
 
 #download tulip_infiniband source code
-RUN git clone --depth=1 https://github.com/nateucar/tulip_infiniband.git /tulip_infiniband
+RUN git clone --depth=1 https://github.com/nateucar/tulip_infiniband.git /src/tulip_infiniband
 
-RUN mkdir /tulip_infiniband/build
+RUN mkdir /src/tulip_infiniband/build
 
-WORKDIR /tulip_infiniband/build
+WORKDIR /src/tulip_infiniband/build
 
 #write makefile, compile in paralled and install tulip_infiniband
-RUN cmake -DCMAKE_MODULE_PATH="/tulip/tulip-src/cmake;/tulip_infiniband" \
-	-DCMAKE_BUILD_TYPE=Release /tulip_infiniband && make -j 4 && make install
+RUN cmake -DCMAKE_MODULE_PATH="/src/tulip/cmake;/src/tulip_infiniband" \
+	-DCMAKE_BUILD_TYPE=Release /src/tulip_infiniband && make -j 4 && make install
 
 CMD env LD_LIBRARY_PATH=/usr/local/lib/tulip/:/usr/local/lib:$LD_LIBRARY_PATH tulip
 

--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -33,6 +33,7 @@ WORKDIR /tulip/tulip-src/build
 RUN cmake .. && make -j 4 && make install
 
 #download re2 source code
+
 RUN git clone --depth=1 https://github.com/google/re2.git /re2
 
 WORKDIR	/re2
@@ -58,6 +59,10 @@ RUN mkdir /tulip_infiniband/build
 WORKDIR /tulip_infiniband/build
 
 #write makefile, compile in paralled and install tulip_infiniband
-RUN cmake -DCMAKE_MODULE_PATH="/tulip/tulip-src/cmake;/tulip_infiniband" -DCMAKE_BUILD_TYPE=Release /tulip_infiniband && make -j 4 && make install
+RUN cmake -DCMAKE_MODULE_PATH="/tulip/tulip-src/cmake;/tulip_infiniband" \
+	-DCMAKE_BUILD_TYPE=Release /tulip_infiniband && make -j 4 && make install
 
-CMD /usr/local/bin/tulip
+CMD env LD_LIBRARY_PATH=/usr/local/lib/tulip/:/usr/local/lib:$LD_LIBRARY_PATH tulip
+
+
+

--- a/contrib/docker/Makefile
+++ b/contrib/docker/Makefile
@@ -1,11 +1,25 @@
 DOCKER_TAG      ?= tulip
 DEBRELEASE      ?= stretch
-RUN_ARGS        ?= docker run --network=host --cap-add=SYS_PTRACE --security-opt=apparmor:unconfined \
+BUILD_ARGS      ?= --rm 
+ifeq ($(shell uname),Linux)
+	OS=Linux
+else ifeq ($(shell uname),Darwin)
+	OS=Mac
+endif
+
+ifeq ($(OS),Linux)
+	RUN_ARGS ?= docker run --network=host --cap-add=SYS_PTRACE --security-opt=apparmor:unconfined \
 	-it --log-driver=syslog -h $(DOCKER_TAG) -v /dev/log:/dev/log --name $(DOCKER_TAG) \
 	-v /tmp/.X11-unix:/tmp/.X11-unix -v /home:/home -v $(XAUTHORITY):$(XAUTHORITY) \
 	-e DISPLAY=unix$(DISPLAY) -e XAUTHORITY=$(XAUTHORITY)
-BUILD_ARGS      ?= --rm  
-        
+else ifeq ($(OS),Mac)
+	RUN_ARGS ?= xhost + $(shell ifconfig en0 | grep inet | awk '$$1=="inet" {print $$2}'); \
+	docker run --network=host --cap-add=SYS_PTRACE --security-opt=apparmor:unconfined \
+	-it -h $(DOCKER_TAG) --name $(DOCKER_TAG) \
+	-e DISPLAY=$(shell ifconfig en0 | grep inet | awk '$$1=="inet" {print $$2}'):0 \
+	-v /tmp/.X11-unix:/tmp/.X11-unix
+endif
+
 default: run
 
 build:  

--- a/contrib/docker/README.md
+++ b/contrib/docker/README.md
@@ -1,0 +1,63 @@
+# Tulip in a Docker container
+Portable Tulip Graphical User Interface
+
+--------------------------------------------------------
+# Linux
+
+## Prerequisites:
+* gcc
+* Docker 
+
+## Build and run Tulip:
+```
+make
+```
+
+## Example: Complete install and run on Ubuntu 18.04 host
+* Install gcc
+```
+sudo apt-get install -y build-essential
+```
+* Install Docker for Linux
+```
+sudo apt install -y docker-ce
+```
+* Build and run Tulip container 
+(must be in <...>/tulip_infiniband/contrib/docker)
+```
+make
+```
+--------------------------------------------------------
+# Macintosh
+
+## Prerequisites:
+* gcc
+* Docker
+* XQuartz
+
+## Build and run Tulip: 
+```
+make
+```
+
+## Example: Complete install and run on macOS 10.12.6 host
+* Install gcc
+```
+xcode-select --install
+```
+* Install Docker for Mac
+```
+brew install docker
+```
+* Install XQuartz
+```
+brew cask install xquartz
+```
+* Build and run Tulip container
+(must be in <...>/tulip_infiniband/contrib/docker)
+```
+make
+```
+--------------------------------------------------------
+# Windows not yet supported
+


### PR DESCRIPTION
Resolves tulip plugin error where libibautils shared object could not be found, and update INSTALL.md to download using git rather than svn. Also changes dockerfile paths to be more sensible. 