### PR TITLE
Adds network interface help to makefile

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -15,7 +15,7 @@ http://tulip.labri.fr/Documentation/current/tulip-dev/html/tulip_tutorial.html
 # Install Procedure
 * Use Cmake to configure
 ```
-cmake -DCMAKE_MODULE_PATH="<path to Tulip source code/cmake>;<path to Infiniband directory>" -DCMAKE_BUILD_TYPE=Release <path to Infiniband directory>
+cmake -DCMAKE_MODULE_PATH="<path to Tulip source code/cmake>;<path to Infiniband directory>" -DCMAKE_BUILD_TYPE=Debug <path to Infiniband directory>
 ```
 * Compile and install
 ```
@@ -34,7 +34,7 @@ git clone --depth=1 --single-branch -b tulip_5_1_0 https://github.com/Tulip-Dev/
 cd tulip-src
 mkdir build
 cd build
-cmake ..
+cmake -DCMAKE_BUILD_TYPE=Debug ..
 make
 sudo make install
 ```
@@ -50,7 +50,7 @@ sudo make install
 git clone https://github.com/nateucar/libibautils.git libibautils
 mkdir libibautils/build
 cd libibautils/build
-cmake ..
+cmake -DCMAKE_BUILD_TYPE=Debug ..
 make
 sudo make install
 ```
@@ -59,7 +59,7 @@ sudo make install
 git clone https://github.com/nateucar/tulip_infiniband.git tulip_infiniband
 mkdir tulip_infiniband/build
 cd tulip_infiniband/build
-cmake -DCMAKE_MODULE_PATH="<path to tulip-src>/cmake;.." -DCMAKE_BUILD_TYPE=Release ..
+cmake -DCMAKE_MODULE_PATH="<path to tulip-src>/cmake;.." -DCMAKE_BUILD_TYPE=Debug ..
 make
 sudo make install
 ```

--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -28,7 +28,7 @@ RUN mkdir /src/tulip/build
 WORKDIR /src/tulip/build
 
 #write makefile, compile in parallel and install tulip
-RUN cmake .. && make -j 4 && make install
+RUN cmake -DCMAKE_BUILD_TYPE=Debug .. && make -j 4 && make install
 
 #download re2 source code
 
@@ -47,7 +47,7 @@ RUN mkdir /src/libibautils/build
 WORKDIR /src/libibautils/build
 
 #write makefile, compile in parallel and install libibautils
-RUN cmake .. && make -j 4 && make install
+RUN cmake -DCMAKE_BUILD_TYPE=Debug .. && make -j 4 && make install
 
 #download tulip_infiniband source code
 RUN git clone --depth=1 https://github.com/nateucar/tulip_infiniband.git /src/tulip_infiniband
@@ -58,7 +58,7 @@ WORKDIR /src/tulip_infiniband/build
 
 #write makefile, compile in paralled and install tulip_infiniband
 RUN cmake -DCMAKE_MODULE_PATH="/src/tulip/cmake;/src/tulip_infiniband" \
-	-DCMAKE_BUILD_TYPE=Release /src/tulip_infiniband && make -j 4 && make install
+	-DCMAKE_BUILD_TYPE=D /src/tulip_infiniband && make -j 4 && make install
 
 CMD env LD_LIBRARY_PATH=/usr/local/lib/tulip/:/usr/local/lib:$LD_LIBRARY_PATH tulip
 

--- a/contrib/docker/Makefile
+++ b/contrib/docker/Makefile
@@ -1,5 +1,5 @@
 DOCKER_TAG      ?= tulip
-DEBRELEASE      ?= stretch
+DEBRELEASE	?= stretch
 BUILD_ARGS      ?= --rm 
 # Optional user-defined variable declaring which network interface to use for Mac
 ETHDEV		:=
@@ -11,17 +11,25 @@ else ifeq ($(shell uname),Darwin)
 	OS=Mac
 endif
 
-# For Mac, determine whether using en0 or en1, unless specified by user
+# For Mac, determine which network interface to use, unless specified by user
 ifeq ($(OS),Mac)
 	ifndef ETHDEV
 		ifneq ($(shell ipconfig getifaddr en0),)
 			ETHDEV=en0
-		else
+		else ifneq ($(shell ipconfig getifaddr en1),)
 			ETHDEV=en1
+		else ifneq ($(shell ipconfig getifaddr en2),)
+			ETHDEV=en2
+		else ifneq ($(shell ipconfig getifaddr en3),)
+			ETHDEV=en3
 		endif
 	endif
 	# Get the ip address
 	IP=$(shell ipconfig getifaddr $(ETHDEV))
+# Define error message if no ip address can be found
+	ifeq ($(IP),)
+		$(error Error, no ip address found)
+	endif
 endif
 
 # Define appropriate arguments for the docker run depending on the operating system.
@@ -41,7 +49,14 @@ endif
 # Define makefile targets
 default: run
 
-build:  
+compat:
+ifeq ($(OS),Mac)
+ifndef IP
+	exit 1
+endif 
+endif
+
+build: compat
 	docker build $(BUILD_ARGS) \
 		--build-arg DEBRELEASE=$(DEBRELEASE) \
 		--network=host -t $(DOCKER_TAG) .
@@ -55,7 +70,7 @@ nocache:
 
 clean: nocache build
 
-run: build stop	
+run: build stop
 	$(RUN_ARGS) -d --restart unless-stopped $(DOCKER_TAG)
 
 debug: build stop
@@ -65,7 +80,7 @@ bash: build stop
 	$(RUN_ARGS) --rm $(DOCKER_TAG) /bin/bash
 
 help: 
-	@echo Execute '"make <target>"' for specific options within the makefile. Targets are described below. The default is run
+	@echo Execute '"make <target>"' for specific options within the makefile. Targets are described below. The default is run. If a specific network interface is desired, define ETHDEV in the make call. For example: make ETHDEV=en1 debug.
 	@echo run:    "\t"  Builds and runs Tulip. Restarts the GUI until process is stopped or the window is closed with the close button
 	@echo debug:  "\t"  Builds and runs Tulip while forwarding any standard output to the terminal
 	@echo bash:   "\t"  Builds the Tulip container but does not run the GUI. User is placed in the container in the terminal

--- a/contrib/docker/Makefile
+++ b/contrib/docker/Makefile
@@ -9,6 +9,8 @@ ifeq ($(shell uname),Linux)
 	OS=Linux
 else ifeq ($(shell uname),Darwin)
 	OS=Mac
+else
+$(error Error, only compatable with Linux and Mac)
 endif
 
 # For Mac, determine which network interface to use, unless specified by user
@@ -27,9 +29,9 @@ ifeq ($(OS),Mac)
 	# Get the ip address
 	IP=$(shell ipconfig getifaddr $(ETHDEV))
 # Define error message if no ip address can be found
-	ifeq ($(IP),)
-		$(error Error, no ip address found)
-	endif
+ifeq ($(IP),)
+$(error Error, no ip address found)
+endif
 endif
 
 # Define appropriate arguments for the docker run depending on the operating system.
@@ -49,14 +51,7 @@ endif
 # Define makefile targets
 default: run
 
-compat:
-ifeq ($(OS),Mac)
-ifndef IP
-	exit 1
-endif 
-endif
-
-build: compat
+build:
 	docker build $(BUILD_ARGS) \
 		--build-arg DEBRELEASE=$(DEBRELEASE) \
 		--network=host -t $(DOCKER_TAG) .

--- a/contrib/docker/Makefile
+++ b/contrib/docker/Makefile
@@ -72,3 +72,4 @@ help:
 	@echo build:  "\t"  Builds the Tulip container
 	@echo stop:   "\t"  Stops the Tulip container and removes the container files from the host system
 	@echo clean:  "\t"  Builds and runs Tulip from scratch. Does not use the cache. This takes a long time
+


### PR DESCRIPTION
In addition to giving instructions for defining ETHDEV in the readme, this adds the instructions to the make help.